### PR TITLE
Include *all* RemixIcons

### DIFF
--- a/packages/react-icons/src/icons/index.js
+++ b/packages/react-icons/src/icons/index.js
@@ -259,11 +259,7 @@ module.exports = {
       name: "Remix Icon",
       contents: [
         {
-          files: path.resolve(__dirname, "RemixIcon/icons/*/*-line.svg"),
-          formatter: name => `Ri${name}`
-        },
-        {
-          files: path.resolve(__dirname, "RemixIcon/icons/*/*-fill.svg"),
+          files: path.resolve(__dirname, "RemixIcon/icons/*/*.svg"),
           formatter: name => `Ri${name}`
         }
       ],


### PR DESCRIPTION
Some are not postfixed with either “line” or “fill” (e.g. those inside of Editor).